### PR TITLE
Query C.1: Reverse subject and object nodes

### DIFF
--- a/2021-12_demo/workflowC/C.1_ChemSubstances_related_to_Disease.json
+++ b/2021-12_demo/workflowC/C.1_ChemSubstances_related_to_Disease.json
@@ -3,8 +3,8 @@
         "query_graph": {
             "edges": {
                 "e00": {
-                    "subject": "n00",
-                    "object": "n01",
+                    "subject": "n01",
+                    "object": "n00",
                     "predicates": [
                         "biolink:has_real_world_evidence_of_association_with"
                     ]


### PR DESCRIPTION
A recent change in the Smart API spec for our EHR risk KP (which defines how TRAPI is converted to an equivalent Smart API query) requires that this query be defined in the reverse direction. Therefore, swap subject and object node IDs. I confirmed that COHD results we currently get still show up when reversing the nodes and EHR risk shows up (through BTE and ARAX) after reversing.