### PR TITLE
Update C.2 queries to use workflow overlays

### DIFF
--- a/2021-12_demo/workflowC/C.2a_Imatinib_MultSclerosis_GeneSet_and_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2a_Imatinib_MultSclerosis_GeneSet_and_SmallMolecule.json
@@ -1,4 +1,41 @@
 {
+    "workflow": [
+        {
+            "id": "fill"
+        },
+        {
+            "id": "bind"
+        },
+        {
+            "id": "overlay_compute_ngd",
+            "parameters": {
+                "virtual_relation_label": "N1",
+                "qnode_keys": [
+                    "n3",
+                    "n1"
+                ]
+            }
+        },
+        {
+            "id": "overlay_compute_ngd",
+            "parameters": {
+                "virtual_relation_label": "N2",
+                "qnode_keys": [
+                    "n2",
+                    "n3"
+                ]
+            }
+        },
+        {
+            "id": "complete_results"
+        },
+        {
+            "id": "filter_results_top_n",
+            "parameters": {
+                "max_results": 500
+            }
+        }
+    ],
     "message": {
         "query_graph": {
             "nodes": {
@@ -64,30 +101,6 @@
                     "object": "n3",
                     "constraints": [],
                     "exclude": false
-                },
-                "N1": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n3",
-                    "object": "n2",
-                    "constraints": []
-                },
-                "N2": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n3",
-                    "object": "n1",
-                    "constraints": []
-                },
-                "N3": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n2",
-                    "object": "n3",
-                    "constraints": []
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.2b_Etanercept_MultSclerosis_GeneSet_and_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2b_Etanercept_MultSclerosis_GeneSet_and_SmallMolecule.json
@@ -1,4 +1,41 @@
 {
+    "workflow": [
+        {
+            "id": "fill"
+        },
+        {
+            "id": "bind"
+        },
+        {
+            "id": "overlay_compute_ngd",
+            "parameters": {
+                "virtual_relation_label": "N1",
+                "qnode_keys": [
+                    "n3",
+                    "n1"
+                ]
+            }
+        },
+        {
+            "id": "overlay_compute_ngd",
+            "parameters": {
+                "virtual_relation_label": "N2",
+                "qnode_keys": [
+                    "n2",
+                    "n3"
+                ]
+            }
+        },
+        {
+            "id": "complete_results"
+        },
+        {
+            "id": "filter_results_top_n",
+            "parameters": {
+                "max_results": 500
+            }
+        }
+    ],
     "message": {
         "query_graph": {
             "nodes": {
@@ -64,30 +101,6 @@
                     "object": "n3",
                     "constraints": [],
                     "exclude": false
-                },
-                "N1": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n3",
-                    "object": "n2",
-                    "constraints": []
-                },
-                "N2": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n3",
-                    "object": "n1",
-                    "constraints": []
-                },
-                "N3": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n2",
-                    "object": "n3",
-                    "constraints": []
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.2c_Natalizumab_MultSclerosis_GeneSet_and_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2c_Natalizumab_MultSclerosis_GeneSet_and_SmallMolecule.json
@@ -1,4 +1,41 @@
 {
+    "workflow": [
+        {
+            "id": "fill"
+        },
+        {
+            "id": "bind"
+        },
+        {
+            "id": "overlay_compute_ngd",
+            "parameters": {
+                "virtual_relation_label": "N1",
+                "qnode_keys": [
+                    "n3",
+                    "n1"
+                ]
+            }
+        },
+        {
+            "id": "overlay_compute_ngd",
+            "parameters": {
+                "virtual_relation_label": "N2",
+                "qnode_keys": [
+                    "n2",
+                    "n3"
+                ]
+            }
+        },
+        {
+            "id": "complete_results"
+        },
+        {
+            "id": "filter_results_top_n",
+            "parameters": {
+                "max_results": 500
+            }
+        }
+    ],
     "message": {
         "query_graph": {
             "nodes": {
@@ -64,30 +101,6 @@
                     "object": "n3",
                     "constraints": [],
                     "exclude": false
-                },
-                "N1": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n3",
-                    "object": "n2",
-                    "constraints": []
-                },
-                "N2": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n3",
-                    "object": "n1",
-                    "constraints": []
-                },
-                "N3": {
-                    "predicates": [
-                        "biolink:has_normalized_google_distance_with"
-                    ],
-                    "subject": "n2",
-                    "object": "n3",
-                    "constraints": []
                 }
             }
         }


### PR DESCRIPTION
For queries C.2a, C.2b, and C.2c, replace non-TRAPI compliant normalized google
distance edges with overlay_compute_ngd operations in workflow section.