### PR TITLE
update PKs; add error handling in agent message retrieval

### DIFF
--- a/2021-12_demo/workflowD/query_helpers.py
+++ b/2021-12_demo/workflowD/query_helpers.py
@@ -234,12 +234,14 @@ def _get_agent_response(child: Dict[str, Any], ars_url: str) -> Tuple[str, Dict[
         ARS's 'children' field in a `_get_ars_result` response
     '''
     agent = child[ARS_RESP_KEY_ACTOR][ARS_RESP_KEY_AGENT]
-
-    if child[ARS_RESP_KEY_STATUS] == ARS_STATUS_DONE:
-        child_response = _get_ars_result(child[ARS_RESP_KEY_MESSAGE], ars_url=ars_url)
-        child_message = child_response[ARS_RESP_KEY_FIELDS][ARS_RESP_KEY_DATA][ARS_RESP_KEY_MESSAGE]
-        
-    else:
+    try:
+        if child[ARS_RESP_KEY_STATUS] == ARS_STATUS_DONE:
+            child_response = _get_ars_result(child[ARS_RESP_KEY_MESSAGE], ars_url=ars_url)
+            child_message = child_response[ARS_RESP_KEY_FIELDS][ARS_RESP_KEY_DATA][ARS_RESP_KEY_MESSAGE]
+        else:
+            child_message = {}
+    except Exception as e:
+        print(f'Error retrieving response from {agent=}')
         child_message = {}
     
     child_results = child_message.get(ARS_RESP_KEY_RESULTS)

--- a/2021-12_demo/workflowD/workflowD.ipynb
+++ b/2021-12_demo/workflowD/workflowD.ipynb
@@ -175,7 +175,7 @@
    "outputs": [],
    "source": [
     "# A cached PK, if necessary\n",
-    "ars_pk_for_query_d1 = 'ee66639b-64e8-47eb-b1f0-9e3ae543b942'"
+    "ars_pk_for_query_d1 = 'abb8f85a-a0cc-4083-aad9-6695cb4b638a'"
    ]
   },
   {
@@ -493,7 +493,7 @@
    "outputs": [],
    "source": [
     "# A cached PK, if necessary\n",
-    "ars_pk_for_query_d2 = '21106e53-ddd3-48fa-bba3-4ace403d5084'"
+    "ars_pk_for_query_d2 = 'd680d232-98d8-4b0b-9767-de7d947ca036'"
    ]
   },
   {
@@ -666,7 +666,7 @@
    "outputs": [],
    "source": [
     "# A cached PK if necessary:\n",
-    "ars_pk_for_query_d3 = '29904f18-172d-45d1-890d-ee8f6a88f671'"
+    "ars_pk_for_query_d3 = '883013f5-4f35-4374-9c70-6fe0e9c3e760'"
    ]
   },
   {
@@ -846,7 +846,7 @@
    "outputs": [],
    "source": [
     "# A cached PK, if necessary\n",
-    "ars_pk_for_query_d4 = '7743fa3b-301f-4d30-b887-48b69d512572'"
+    "ars_pk_for_query_d4 = 'f87aa74f-921e-449e-af56-11e089a6b9da'"
    ]
   },
   {
@@ -1090,8 +1090,8 @@
    "outputs": [],
    "source": [
     "# A cached PK, almost certainly necessary\n",
-    "ars_pk_for_query_d6 = '1fc93e47-36ec-4f6a-8e99-58c2bf647cb9'\n",
-    "async_ars_pk_for_query_d6 = '0c2a93db-02ad-4a90-a070-e88a60377673'"
+    "ars_pk_for_query_d6 = 'e9549e6b-035d-4476-bfc5-9eeede53ad41'\n",
+    "async_ars_pk_for_query_d6 = 'c197d1a6-5328-4e14-99e2-e338c8a4a548'"
    ]
   },
   {
@@ -1136,6 +1136,7 @@
     "expected_d6_results = {\n",
     "    query_d6_node_of_interest_n01: [\n",
     "        'UniProtKB:P54646',  # AAPK\n",
+    "        'UniProtKB:Q9Y478',  # AAKB1\n",
     "        'NCBIGene:5563'  #AMPK gene\n",
     "    ],\n",
     "    query_d6_node_of_interest_n02: [\n",


### PR DESCRIPTION
This updates the workflow D notebook with newer PKs.

It also adds some error handling when failing to retrieve agent responses.

Finally, it adds an additional CURIE to expect for in query D.6.