### PR TITLE
Remove unused portions of queries

### DIFF
--- a/2021-12_demo/workflowC/C.1_Template_SmallMolecule_real_world_evidence_Disease.json
+++ b/2021-12_demo/workflowC/C.1_Template_SmallMolecule_real_world_evidence_Disease.json
@@ -9,15 +9,13 @@
                     "ids": [
                         "[CURIE-FOR-SPECIFIC-DISEASE-OF-INTEREST]"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n01": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -26,9 +24,7 @@
                     "object": "n01",
                     "predicates": [
                         "biolink:has_real_world_evidence_of_association_with"
-                    ],
-                    "constraints": [],
-                    "exclude": false
+                    ]
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.1a_SmallMolecule_real_world_evidence_MultSclerosis.json
+++ b/2021-12_demo/workflowC/C.1a_SmallMolecule_real_world_evidence_MultSclerosis.json
@@ -9,15 +9,13 @@
                     "ids": [
                         "MONDO:0005301"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n01": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -26,9 +24,7 @@
                     "object": "n01",
                     "predicates": [
                         "biolink:has_real_world_evidence_of_association_with"
-                    ],
-                    "constraints": [],
-                    "exclude": false
+                    ]
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.2_Template_Drug_Disease_GeneSet_interacts_with_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2_Template_Drug_Disease_GeneSet_interacts_with_SmallMolecule.json
@@ -43,8 +43,7 @@
                     "categories": [
                         "biolink:Gene"
                     ],
-                    "is_set": true,
-                    "constraints": []
+                    "is_set": true
                 },
                 "n1": {
                     "ids": [
@@ -53,8 +52,7 @@
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n2": {
                     "ids": [
@@ -63,15 +61,13 @@
                     "categories": [
                         "biolink:Disease"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n3": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -80,27 +76,21 @@
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n1",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n1"
                 },
                 "e02": {
                     "predicates": [
                         "biolink:genetic_association"
                     ],
                     "subject": "n0",
-                    "object": "n2",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n2"
                 },
                 "e03": {
                     "predicates": [
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n3",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n3"
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.2a_Imatinib_MultSclerosis_GeneSet_and_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2a_Imatinib_MultSclerosis_GeneSet_and_SmallMolecule.json
@@ -1,41 +1,4 @@
 {
-    "workflow": [
-        {
-            "id": "fill"
-        },
-        {
-            "id": "bind"
-        },
-        {
-            "id": "overlay_compute_ngd",
-            "parameters": {
-                "virtual_relation_label": "N1",
-                "qnode_keys": [
-                    "n3",
-                    "n1"
-                ]
-            }
-        },
-        {
-            "id": "overlay_compute_ngd",
-            "parameters": {
-                "virtual_relation_label": "N2",
-                "qnode_keys": [
-                    "n2",
-                    "n3"
-                ]
-            }
-        },
-        {
-            "id": "complete_results"
-        },
-        {
-            "id": "filter_results_top_n",
-            "parameters": {
-                "max_results": 500
-            }
-        }
-    ],
     "message": {
         "query_graph": {
             "nodes": {
@@ -43,8 +6,7 @@
                     "categories": [
                         "biolink:Gene"
                     ],
-                    "is_set": true,
-                    "constraints": []
+                    "is_set": true
                 },
                 "n1": {
                     "ids": [
@@ -53,8 +15,7 @@
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n2": {
                     "ids": [
@@ -63,15 +24,13 @@
                     "categories": [
                         "biolink:Disease"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n3": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -80,27 +39,21 @@
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n1",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n1"
                 },
                 "e02": {
                     "predicates": [
                         "biolink:genetic_association"
                     ],
                     "subject": "n0",
-                    "object": "n2",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n2"
                 },
                 "e03": {
                     "predicates": [
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n3",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n3"
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.2b_Etanercept_MultSclerosis_GeneSet_and_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2b_Etanercept_MultSclerosis_GeneSet_and_SmallMolecule.json
@@ -1,41 +1,4 @@
 {
-    "workflow": [
-        {
-            "id": "fill"
-        },
-        {
-            "id": "bind"
-        },
-        {
-            "id": "overlay_compute_ngd",
-            "parameters": {
-                "virtual_relation_label": "N1",
-                "qnode_keys": [
-                    "n3",
-                    "n1"
-                ]
-            }
-        },
-        {
-            "id": "overlay_compute_ngd",
-            "parameters": {
-                "virtual_relation_label": "N2",
-                "qnode_keys": [
-                    "n2",
-                    "n3"
-                ]
-            }
-        },
-        {
-            "id": "complete_results"
-        },
-        {
-            "id": "filter_results_top_n",
-            "parameters": {
-                "max_results": 500
-            }
-        }
-    ],
     "message": {
         "query_graph": {
             "nodes": {
@@ -43,8 +6,7 @@
                     "categories": [
                         "biolink:Gene"
                     ],
-                    "is_set": true,
-                    "constraints": []
+                    "is_set": true
                 },
                 "n1": {
                     "ids": [
@@ -53,8 +15,7 @@
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n2": {
                     "ids": [
@@ -63,15 +24,13 @@
                     "categories": [
                         "biolink:Disease"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n3": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -80,27 +39,21 @@
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n1",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n1"
                 },
                 "e02": {
                     "predicates": [
                         "biolink:genetic_association"
                     ],
                     "subject": "n0",
-                    "object": "n2",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n2"
                 },
                 "e03": {
                     "predicates": [
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n3",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n3"
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.2c_Natalizumab_MultSclerosis_GeneSet_and_SmallMolecule.json
+++ b/2021-12_demo/workflowC/C.2c_Natalizumab_MultSclerosis_GeneSet_and_SmallMolecule.json
@@ -1,41 +1,4 @@
 {
-    "workflow": [
-        {
-            "id": "fill"
-        },
-        {
-            "id": "bind"
-        },
-        {
-            "id": "overlay_compute_ngd",
-            "parameters": {
-                "virtual_relation_label": "N1",
-                "qnode_keys": [
-                    "n3",
-                    "n1"
-                ]
-            }
-        },
-        {
-            "id": "overlay_compute_ngd",
-            "parameters": {
-                "virtual_relation_label": "N2",
-                "qnode_keys": [
-                    "n2",
-                    "n3"
-                ]
-            }
-        },
-        {
-            "id": "complete_results"
-        },
-        {
-            "id": "filter_results_top_n",
-            "parameters": {
-                "max_results": 500
-            }
-        }
-    ],
     "message": {
         "query_graph": {
             "nodes": {
@@ -43,8 +6,7 @@
                     "categories": [
                         "biolink:Gene"
                     ],
-                    "is_set": true,
-                    "constraints": []
+                    "is_set": true
                 },
                 "n1": {
                     "ids": [
@@ -53,8 +15,7 @@
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n2": {
                     "ids": [
@@ -63,15 +24,13 @@
                     "categories": [
                         "biolink:Disease"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n3": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -80,27 +39,21 @@
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n1",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n1"
                 },
                 "e02": {
                     "predicates": [
                         "biolink:genetic_association"
                     ],
                     "subject": "n0",
-                    "object": "n2",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n2"
                 },
                 "e03": {
                     "predicates": [
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n3",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n3"
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.3_Template_Disease_related_to_Drug.json
+++ b/2021-12_demo/workflowC/C.3_Template_Disease_related_to_Drug.json
@@ -9,8 +9,7 @@
                     "ids": [
                         "[CURIE-FOR-SPECIFIC-DISEASE-IN-QUERIES-C1-C2]"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n01": {
                     "categories": [
@@ -19,8 +18,7 @@
                     "ids": [
                         "[CURIE-FOR-SPECIFIC-DRUG-FROM-QUERY-C2-RESULTS]"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -29,9 +27,7 @@
                     "object": "n01",
                     "predicates": [
                         "biolink:related_to"
-                    ],
-                    "constraints": [],
-                    "exclude": false
+                    ]
                 }
             }
         }

--- a/2021-12_demo/workflowC/C.3a_MultSclerosis_related_to_Nimodipine.json
+++ b/2021-12_demo/workflowC/C.3a_MultSclerosis_related_to_Nimodipine.json
@@ -9,8 +9,7 @@
                     "ids": [
                         "MONDO:0005301"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n01": {
                     "categories": [
@@ -19,8 +18,7 @@
                     "ids": [
                         "CHEMBL.COMPOUND:CHEMBL1428"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -29,9 +27,7 @@
                     "object": "n01",
                     "predicates": [
                         "biolink:related_to"
-                    ],
-                    "constraints": [],
-                    "exclude": false
+                    ]
                 }
             }
         }

--- a/2021-12_demo/workflowC/README.md
+++ b/2021-12_demo/workflowC/README.md
@@ -71,15 +71,13 @@ Results: https://arax.ncats.io/?r=27565
                     "ids": [
                         "MONDO:0005301"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n01": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -88,9 +86,7 @@ Results: https://arax.ncats.io/?r=27565
                     "object": "n01",
                     "predicates": [
                         "biolink:has_real_world_evidence_of_association_with"
-                    ],
-                    "constraints": [],
-                    "exclude": false
+                    ]
                 }
             }
         }
@@ -148,8 +144,7 @@ Results: https://arax.ncats.io/?r=27108
                     "categories": [
                         "biolink:Gene"
                     ],
-                    "is_set": true,
-                    "constraints": []
+                    "is_set": true
                 },
                 "n1": {
                     "ids": [
@@ -158,8 +153,7 @@ Results: https://arax.ncats.io/?r=27108
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n2": {
                     "ids": [
@@ -168,15 +162,13 @@ Results: https://arax.ncats.io/?r=27108
                     "categories": [
                         "biolink:Disease"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n3": {
                     "categories": [
                         "biolink:SmallMolecule"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -185,27 +177,21 @@ Results: https://arax.ncats.io/?r=27108
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n1",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n1"
                 },
                 "e02": {
                     "predicates": [
                         "biolink:genetic_association"
                     ],
                     "subject": "n0",
-                    "object": "n2",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n2"
                 },
                 "e03": {
                     "predicates": [
                         "biolink:interacts_with"
                     ],
                     "subject": "n0",
-                    "object": "n3",
-                    "constraints": [],
-                    "exclude": false
+                    "object": "n3"
                 }
             }
         }
@@ -229,8 +215,7 @@ Results: https://arax.ncats.io/?r=b7a43315-377e-40c9-9f6b-c92a8295f7d2
                     "ids": [
                         "MONDO:0005301"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 },
                 "n01": {
                     "categories": [
@@ -239,8 +224,7 @@ Results: https://arax.ncats.io/?r=b7a43315-377e-40c9-9f6b-c92a8295f7d2
                     "ids": [
                         "CHEMBL.COMPOUND:CHEMBL1487"
                     ],
-                    "is_set": false,
-                    "constraints": []
+                    "is_set": false
                 }
             },
             "edges": {
@@ -249,9 +233,7 @@ Results: https://arax.ncats.io/?r=b7a43315-377e-40c9-9f6b-c92a8295f7d2
                     "object": "n01",
                     "predicates": [
                         "biolink:related_to"
-                    ],
-                    "constraints": [],
-                    "exclude": false
+                    ]
                 }
             }
         }


### PR DESCRIPTION
Remove empty "constraint" portions of queries as well as "exclude" attributes.
Remove workflow sections of non-template queries so that results from more ARAs
will be returned. Also, removing the workflow sections means that results from
these queries will show up in the workflow progress tracker. Note that the
workflow section is retained in the C.2 template query.